### PR TITLE
Remove YYYY-MM-DD from docs

### DIFF
--- a/source/methods/payrolls.md.erb
+++ b/source/methods/payrolls.md.erb
@@ -37,8 +37,8 @@ This method allows you to list payroll periods or find ones within a specified d
 
 Key | Description
 --- | -----------
-start | <strong>datetime</strong><br />Start date of search range (YYYY-MM-DD)
-end | <strong>datetime</strong><br />End date of search range (YYYY-MM-DD)
+start | <strong>datetime</strong><br />Start date of search range
+end | <strong>datetime</strong><br />End date of search range
 
 
 

--- a/source/methods/times.md.erb
+++ b/source/methods/times.md.erb
@@ -45,8 +45,8 @@ This method allows you to list times or find ones within a specified date range.
 
 Key | Description
 --- | -----------
-start | Start date of search range (YYYY-MM-DD)
-end | End date of search range (YYYY-MM-DD)
+start | Start date of search range
+end | End date of search range
 user_id | The ID of the user to get times for. To get times for multiple users, you can enter multiple ids separated by commas.
 
 


### PR DESCRIPTION
Some sections of the docs seemed to indicate that you needed to enter start and end dates in the format YYYY-MM-DD. This was misleading, since those endpoints do in fact accept dates in a more specific format.

At some point, maybe we could put in a section near the top explaining what date formats will be accepted throughout the API.