### PR TITLE
Enable Markdown parsing in asides

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,7 +1,10 @@
 require "lib/api_objects"
+require "lib/common"
 ::Middleman::Extensions.register(:api_objects, ApiObjects)
+::Middleman::Extensions.register(:common, Common)
 
 activate :api_objects
+activate :common
 
 set :css_dir, 'stylesheets'
 
@@ -32,6 +35,7 @@ page "*" do
   @api_prefix = "https://api.wheniwork.com"
   @wiw_key = "iworksoharditsnotfunny"
   @wiw_token = "ilovemyboss"
+  @markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(), {})
 end
 
 

--- a/lib/common.rb
+++ b/lib/common.rb
@@ -1,0 +1,23 @@
+class Common < Middleman::Extension
+  def initialize(app, options_hash={}, &block)
+    super
+    @objects = {}
+
+    # Add helper functions to the App scope
+    app.extend CommonMethods
+  end
+
+  module CommonMethods
+  end
+
+  helpers do
+    def aside(content, options={})
+      asideClass = 'notice'
+      if options[:class]
+        asideClass = options[:class]
+      end
+
+      "<aside class=\"#{asideClass}\">#{@markdown.render(content)}</aside>"
+    end
+  end
+end

--- a/lib/common.rb
+++ b/lib/common.rb
@@ -11,13 +11,23 @@ class Common < Middleman::Extension
   end
 
   helpers do
-    def aside(content, options={})
+
+    # Creates an aside with markdown formatting. Because of stupid problems
+    # with ERB, this cannot be echoed normally, and handles output itself instead.
+    # So you have to call it with <%= this syntax %>, instead of <% this %>.
+    def aside(options={})
+      # ERB is terrible, so we have to "capture" the
+      # contents of the block we just passed in.
+      # http://apidock.com/rails/ActionView/Helpers/CaptureHelper/capture
+      content = capture do yield end
+
       asideClass = 'notice'
       if options[:class]
         asideClass = options[:class]
       end
 
-      "<aside class=\"#{asideClass}\">#{@markdown.render(content)}</aside>"
+      concat "<aside class=\"#{asideClass}\">#{@markdown.render(content)}</aside>"
     end
+    
   end
 end

--- a/source/index.md.erb
+++ b/source/index.md.erb
@@ -75,9 +75,7 @@ $result = Wheniwork::login(
 
 The first thing to do after you receive your Developer Key is to login to get your token. After receiving your token, you will make all future requests using your token in the header of the request.
 
-<aside class="notice">
-Remember — All post bodies must be JSON encoded data (no form data).
-</aside>
+<%= aside "Remember — All post bodies must be JSON encoded data (no form data)." %>
 
 ### Parameters
 

--- a/source/index.md.erb
+++ b/source/index.md.erb
@@ -75,7 +75,9 @@ $result = Wheniwork::login(
 
 The first thing to do after you receive your Developer Key is to login to get your token. After receiving your token, you will make all future requests using your token in the header of the request.
 
-<%= aside "Remember — All post bodies must be JSON encoded data (no form data)." %>
+<% aside do %>
+  Remember — All post bodies must be JSON encoded data (no form data).
+<% end %>
 
 ### Parameters
 

--- a/source/methods/payrolls.md.erb
+++ b/source/methods/payrolls.md.erb
@@ -84,10 +84,14 @@ id | ID of the pay period requested.
 
 The `PUT` body can include fields from the [Payroll Object](#payrolls).
 
-<%= aside "Payrolls can not be manually created." %>
+<% aside do %>
+  Payrolls can not be manually created.
+<% end %>
 
 
 
 ## Delete Existing Payroll
 &nbsp;
-<%= aside "Payrolls can not be deleted." %>
+<% aside do %>
+  Payrolls can not be deleted.
+<% end %>

--- a/source/methods/payrolls.md.erb
+++ b/source/methods/payrolls.md.erb
@@ -84,14 +84,10 @@ id | ID of the pay period requested.
 
 The `PUT` body can include fields from the [Payroll Object](#payrolls).
 
-<aside class='alert'>
-Payrolls can not be manually created.
-</aside>
+<%= aside "Payrolls can not be manually created." %>
 
 
 
 ## Delete Existing Payroll
 &nbsp;
-<aside class='alert'>
-Payrolls can not be deleted.
-</aside>
+<%= aside "Payrolls can not be deleted." %>

--- a/source/methods/plans.md.erb
+++ b/source/methods/plans.md.erb
@@ -6,9 +6,8 @@
 ```
 
 Get all plans.
-<aside class='warning'>
-This list could include legacy plans. These plans, where is_legacy is true, cannot be applied to an account. The only exist to show information relating to the current account.
-</aside>
+
+<%= aside "This list could include legacy plans. These plans, where is_legacy is true, cannot be applied to an account. The only exist to show information relating to the current account.", :class => 'warning' %>
 
 <%= print_table(data.objects['plan'], :header => :plan) %>
 

--- a/source/methods/plans.md.erb
+++ b/source/methods/plans.md.erb
@@ -7,7 +7,9 @@
 
 Get all plans.
 
-<%= aside "This list could include legacy plans. These plans, where is_legacy is true, cannot be applied to an account. The only exist to show information relating to the current account.", :class => 'warning' %>
+<% aside :class => 'warning' do %>
+  This list could include legacy plans. These plans, where is_legacy is true, cannot be applied to an account. The only exist to show information relating to the current account.
+<% end %>
 
 <%= print_table(data.objects['plan'], :header => :plan) %>
 

--- a/source/methods/times.md.erb
+++ b/source/methods/times.md.erb
@@ -145,9 +145,7 @@ Key | Description
 --- | -----------
 id | The ID of the user to get times for.
 
-<aside class='notice'>
-This endpoint does not support start and end times for your query. To filter a user's times by a start and end date, use the [Listing Times](#listing-times) endpoint instead.
-</aside>
+<%= aside "This endpoint does not support start and end times for your query. To filter a user's times by a start and end date, use the [Listing Times](#listing-times) endpoint instead." %>
 
 
 

--- a/source/methods/times.md.erb
+++ b/source/methods/times.md.erb
@@ -145,7 +145,9 @@ Key | Description
 --- | -----------
 id | The ID of the user to get times for.
 
-<%= aside "This endpoint does not support start and end times for your query. To filter a user's times by a start and end date, use the [Listing Times](#listing-times) endpoint instead." %>
+<% aside do %>
+  This endpoint does not support start and end times for your query. To filter a user's times by a start and end date, use the [Listing Times](#listing-times) endpoint instead.
+<% end %>
 
 
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -391,6 +391,11 @@ html, body {
       @extend %icon-ok-sign;
       line-height: 1.4;
     }
+
+    p {
+      line-height: inherit;
+      display: inline;
+    }
   }
 
   a {


### PR DESCRIPTION
More complicated than I wanted it to be, but it works, and we can keep RedCarpet as our Markdown parser.