### PR TITLE
Enable collapsible sections of JSON

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,7 @@
 require "lib/api_objects"
 require "lib/common"
+require "lib/api_html_renderer"
+
 ::Middleman::Extensions.register(:api_objects, ApiObjects)
 ::Middleman::Extensions.register(:common, Common)
 
@@ -14,16 +16,19 @@ set :images_dir, 'images'
 
 set :fonts_dir, 'fonts'
 
-set :markdown_engine, :redcarpet
 
-set :markdown, 
+# Set rendering options. :with_toc_data is ignored for some
+# reason unless we put it in the renderer's constructor.
+set :markdown_engine, :redcarpet
+set :markdown,
       :fenced_code_blocks => true, 
       :smartypants => true, 
       :disable_indented_code_blocks => true, 
       :prettify => true, 
-      :tables => true, 
-      :with_toc_data => true, 
-      :no_intra_emphasis => true
+      :tables => true,
+      :no_intra_emphasis => true,
+      :renderer => APIHtmlRenderer.new(:with_toc_data => true)
+
 
 # Activate the syntax highlighter
 activate :syntax

--- a/lib/api_html_renderer.rb
+++ b/lib/api_html_renderer.rb
@@ -1,0 +1,69 @@
+# 
+# Custom renderer that lets us manipulate how code is outputted
+# (and anything else we decide to implement!)
+# 
+# If any rendering problems come up, esp. related to images or
+# links, check out the class linked below and try to duplicate
+# what it does. Middleman uses a custom RedCarpet renderer by
+# default, which apparently fixes a couple small issues.
+# 
+# https://github.com/middleman/middleman/blob/v3-stable/middleman-core/lib/middleman-core/renderers/redcarpet.rb#L51-L82
+# 
+class APIHtmlRenderer < ::Redcarpet::Render::HTML
+  def initialize(options={})
+    @local_options = options.dup
+    @code_section_counter = 0
+
+    super
+  end
+
+  def block_code(code, language)
+    return Middleman::Syntax::Highlighter.highlight(code, language) unless language == 'json' && code.include?("SECTION_START")
+
+    # -------------------------------------------------------
+    # This lets us show/hide lines in code examples on the
+    # right of the API docs. Currently it is only enabled for
+    # JSON, but this could easily be changed in the future.
+    # -------------------------------------------------------
+
+    # Give each block of code a unique ID
+    @code_section_counter += 1
+
+    # Make sure "SECTION_START" or "SECTION_END" is the
+    # only thing on that line to ensure that it colors
+    # and replaces as expected
+    code.gsub!(/^.*SECTION_START.*\n/, 'SECTION_START')
+    code.gsub!(/^.*SECTION_END.*\n/, 'SECTION_END')
+
+    # Color the code and replace start/end tags with
+    # actual HTML tags
+    output = Middleman::Syntax::Highlighter.highlight(code, language)
+    output.gsub!('<span class="err">SECTION_START</span>', '<span class="hide-section">')
+    output.gsub!('<span class="err">SECTION_END</span>', '</span>')
+
+    # Give the code block its unique ID
+    output.gsub!('<pre', "<pre id=\"code-collapse-#{@code_section_counter}\"")
+
+    # Make and add show/hide links
+    selector = "\#code-collapse-#{@code_section_counter}"
+    expand_link = expand_link(selector)
+    collapse_link = collapse_link(selector)
+    output.gsub!('</pre>', "#{expand_link}#{collapse_link}</pre>")
+
+    return output
+  end
+
+  private
+
+  def toggle_link(klass, selector, message)
+    "<a class=\"#{klass}\" onclick=\"toggleSection('#{selector}')\">#{message}</a>"
+  end
+
+  def expand_link(selector, message = "Show more fields")
+    toggle_link('expand-link', selector, message)
+  end
+
+  def collapse_link(selector, message = "Hide extra fields")
+    toggle_link('collapse-link', selector, message)
+  end
+end

--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -1,2 +1,6 @@
 //= require './jquery_ui'
 //= require_tree .
+
+function toggleSection(selector) {
+    $(selector).toggleClass('expanded');
+}

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -444,6 +444,39 @@ html, body {
     code {
       padding: 0;
     }
+
+    .hide-section {
+      display: none;
+    }
+
+    .expand-link, .collapse-link {
+      cursor: pointer;
+      font-style: italic;
+      color: #ccc;
+      border-color: #aaa;
+    }
+
+    .expand-link {
+      display: inline;
+    }
+
+    .collapse-link {
+      display: none;
+    }
+
+    &.expanded {
+      .hide-section {
+        display: inline;
+      }
+
+      .expand-link {
+        display: none;
+      }
+
+      .collapse-link {
+        display: inline;
+      }
+    }
   }
 
   blockquote {


### PR DESCRIPTION
Sections of JSON code can now be hidden until they are expanded by the user. To do this, just enclose the code to hide between two new lines, one with SECTION_START and one with SECTION_END. As long as those words are somewhere on those lines, it'll work.

For example, `email` and `phone_number` would both be hidden until the user expands them:

```json
{
  "id": 4364,
  "first_name": "Goldie",
  "last_name": "Wilson",
SECTION_START
  "email": "goldiewilson@hillvalleycalifornia.gov",
  "phone_number": "555-555-5555"
SECTION_END
}
```

To accomplish this feature I had to create a new Markdown renderer. Eventually we may even extend this to do other things, but for now it just handles this specific feature.