### PR TITLE
Add ability to collapse tables

### DIFF
--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -64,7 +64,7 @@ $(document).ready(function() {
         var linkTarget = $(this).attr("href");
         
         var scrollTo = $(linkTarget).offset().top - 40;
-        if ($(document).scrollTop() > scrollTo) {
+        if ($(this).hasClass("collapse-link") && $(document).scrollTop() > scrollTo) {
             $("html, body").scrollTop($(linkTarget).offset().top - 40);
         }
     });

--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -1,6 +1,71 @@
 //= require './jquery_ui'
 //= require_tree .
 
-function toggleSection(selector) {
+function toggleCodeSection(selector) {
     $(selector).toggleClass('expanded');
 }
+
+function toggleTable(selector) {
+    if ($(selector).hasClass('expanded')) {
+        collapseTable(selector);
+    } else {
+        expandTable(selector);
+    }
+}
+
+function collapseTable(selector) {
+    function processRow(sip, ns) {
+        var sectionInProgress = sip;
+        var needsSpacer = ns;
+
+        return function(i, tr) {
+            var rowCanCollapse = $(tr).hasClass("collapse");
+            if (rowCanCollapse) {
+                sectionInProgress = true;
+                needsSpacer = !needsSpacer;
+            } else if (sectionInProgress) {
+                sectionInProgress = false;
+                if (needsSpacer) {
+                    $(tr).before($('<tr class="spacer"></tr>'));
+                }
+                needsSpacer = false;
+            }
+        }
+    }
+
+    var table = $(selector).eq(0);
+
+    if (! $(table).hasClass('expanded')) {
+        return;
+    }
+
+    var sectionInProgress = false;
+    var needsSpacer = false;
+    $(table).find('tr').each(processRow(sectionInProgress, needsSpacer));
+
+    $(table).removeClass('expanded');
+}
+
+function expandTable(selector) {
+    var table = $(selector).eq(0);
+
+    if ($(table).hasClass('expanded')) {
+        return;
+    }
+
+    $(table).find('tr.spacer').remove();
+
+    $(table).addClass('expanded');
+}
+
+$(document).ready(function() {
+    $('.collapse-links a').on('click', function(event) {
+        event.preventDefault();
+        var linkTarget = $(this).attr("href");
+        
+        var scrollTo = $(linkTarget).offset().top - 40;
+        if ($(document).scrollTop() > scrollTo) {
+            $("html, body").scrollTop($(linkTarget).offset().top - 40);
+        }
+    });
+});

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -319,7 +319,7 @@ html, body {
       padding: 10px;
     }
 
-    tr:last-child {
+    tbody {
       border-bottom: 2px solid #ccc;
     }
 
@@ -329,6 +329,36 @@ html, body {
 
     tr:nth-child(even)>td {
       background-color: $main-bg;
+    }
+
+    tr.spacer, tr.collapse {
+      display: none;
+    }
+
+    &.expanded tr.collapse {
+      display: table-row;
+    }
+
+    & + .collapse-links {
+      font-style: italic;
+      
+      .expand-link {
+        display: block;
+      }
+
+      .collapse-link {
+        display: none;
+      }
+    }
+
+    &.expanded + .collapse-links {
+      .expand-link {
+        display: none;
+      }
+
+      .collapse-link {
+        display: block;
+      }
     }
   }
 


### PR DESCRIPTION
Tables can now be collapsed, much like blocks of code. Surrounding rows with SECTION_START and SECTION_END will collapse those rows by default. Then clicking a link that appears below the table will expand those rows to allow you to see everything.

Here's an example of what the syntax might look like:

```
Key | Description
--- | -----------
start | <strong>datetime</strong><br />Start time for a search window
end | <strong>datetime</strong><br />End time for a search window
user_id | <strong>integer, string array</strong><br />Only show shifts for a user, or multiple (e.g. 1,5,3)
location_id | <strong>integer, string array</strong><br />Only show shifts for a location, or multiple.
site_id | <strong>integer, string array</strong><br />Only show shifts for a site, or multiple.
position_id | <strong>integer, string array</strong><br />Only show shifts for a position, or multiple.
SECTION_START |
include_allopen | <strong>boolean</strong><br />Include OpenShifts in the results.
include_onlyopen | <strong>boolean</strong><br />Only return OpenShifts in the results
SECTION_END |
```