### PR TITLE
Improve docs for shifts

### DIFF
--- a/data/objects.json
+++ b/data/objects.json
@@ -74,9 +74,14 @@
       "value": 10000,
       "show": true
     },
+    "account_id": {
+      "type": "integer",
+      "description": "Link identifier for the Account to which this shift is attached.",
+      "value": 10000
+    },
     "user_id": {
       "type": "integer",
-      "description": "Link identifier for the User attached to this shift. 0 means OpenShift.",
+      "description": "Link identifier for the User attached to this shift. `0` means the shift is an OpenShift.",
       "value": 101
     },
     "location_id": {
@@ -86,12 +91,12 @@
     },
     "position_id": {
       "type": "integer",
-      "description": "Link identifier for the Position attached to this shift.",
+      "description": "Link identifier for the Position assigned to this shift.",
       "value": 19483
     },
     "site_id": {
       "type": "integer",
-      "description": "Link identifier for the Site attached to this shift.",
+      "description": "Link identifier for the Site assigned to this shift.",
       "value": 4351
     },
     "start_time": {
@@ -108,7 +113,7 @@
     },
     "break_time": {
       "type": "float",
-      "description": "Hours of unpaid break.",
+      "description": "Hours of unpaid break during the shift.",
       "value": 0.5
     },
     "color": {
@@ -118,17 +123,17 @@
     },
     "notes": {
       "type": "string",
-      "description": "Notes about the shift. Max length 350.",
-      "value": "We need more cow bell."
+      "description": "Notes about the shift. The maximum length is 350 characters.",
+      "value": "We need more cowbell."
     },
     "instances": {
       "type": "integer",
-      "description": "Number of instances. Will be 1 if it is a shift assigned to an employee. The value can be any integer greater than 0 if it is an OpenShift.",
+      "description": "For OpenShifts, how many instances of that shift are available to assign to employees. In the UI, this is indicated by the red badge on the OpenShift. For normal shifts, this will be `1`.",
       "value": 1
     },
     "published": {
       "type": "boolean",
-      "description": "Published shifts show to employees.",
+      "description": "Whether the shift has been published. Published shifts are visible to all employees.",
       "value": true
     },
     "published_date": {
@@ -138,18 +143,37 @@
     },
     "notified_at": {
       "type": "datetime",
-      "description": "Date the shift was most recently notified.",
+      "description": "Date when notifications about the shift were most recently sent.",
       "value": null
     },
     "created_at": {
       "type": "datetime",
-      "description": "Date at which the shift was created.",
+      "description": "Date the shift was created.",
       "value": "Thu, 06 Mar 2014 21:12:14 -0600"
     },
     "updated_at": {
       "type": "datetime",
       "description": "Date the shift was most recently updated.",
       "value": "Thu, 06 Mar 2014 22:17:14 -0600"
+    },
+    "acknowledged": {
+      "type": "integer",
+      "description": "Whether the shift has been acknowledged by the employee. (`0` for false, `1` for true.)",
+      "value": 0
+    },
+    "acknowledged_at": {
+      "type": "datetime",
+      "description": "The time, if any, when the shift was acknowledged by the employee.",
+      "value": ""
+    },
+    "creator_id": {
+      "type": "integer",
+      "description": "The id of the user who created the shift.",
+      "value": 101
+    },
+    "is_open": {
+      "type": "boolean",
+      "description": "Whether the shift is an OpenShift."
     }
   },
   "user": {

--- a/source/methods/shifts.md.erb
+++ b/source/methods/shifts.md.erb
@@ -14,7 +14,7 @@ Shifts provide the basis for scheduling. Many other objects, including Locations
 > Example Request
 
 ```shell
-curl <%=@api_prefix%>/2/shifts/?location_id=1&start=2014-03-05 \
+curl <%=@api_prefix%>/2/shifts/?location_id=1&start=2014-03-05 00:00:00&end=2014-03-08 23:59:59 \
  -H "W-Token: <%=@wiw_token%>"
 ```
 ```php
@@ -22,7 +22,8 @@ curl <%=@api_prefix%>/2/shifts/?location_id=1&start=2014-03-05 \
 $wiw = new Wheniwork("<%=@wiw_token%>");
 $result = $wiw->get("shifts", array(
                                 "location_id" => 1, 
-                                "start"  => "2014-03-05"
+                                "start" => "2014-03-05 00:00:00",
+                                "end" => "2014-03-08 23:59:59"
                               ));
 ?>
 ```
@@ -36,7 +37,9 @@ $result = $wiw->get("shifts", array(
   "shifts": [
     <%= print_json(data.objects['shift'], :minimal=>true) %>,
     <%= print_json(data.objects['shift'], :minimal=>true, :include=>{
-      'id'=>27384
+      'id' => 27384,
+      'start_time' => 'Sat, 08 Mar 2014 09:00:00 -0600',
+      'end_time' => 'Sat, 08 Mar 2014 17:00:00 -0600'
     }) %>
   ]
 }
@@ -51,14 +54,19 @@ This method allows you to search for shifts. See the parameters below for all th
 
 Key | Description
 --- | -----------
-start | <strong>datetime</strong><br />Start time for a search window
-end | <strong>datetime</strong><br />End time for a search window
-user_id | <strong>integer, string array</strong><br />Only show shifts for a user, or multiple (e.g. 1,5,3)
-location_id | <strong>integer, string array</strong><br />Only show shifts for a location, or multiple.
-site_id | <strong>integer, string array</strong><br />Only show shifts for a site, or multiple.
-position_id | <strong>integer, string array</strong><br />Only show shifts for a position, or multiple.
-include_allopen | <strong>boolean</strong><br />Include OpenShifts in the results.
-include_onlyopen | <strong>boolean</strong><br />Only return OpenShifts in the results
+start | <strong>datetime</strong><br />Start time for the search window. The default is the current date and time.
+end | <strong>datetime</strong><br />End time for the search window. The default is exactly three days from the start time.
+user_id | <strong>integer, string array</strong><br />The ID of the user to get shifts for. For multiple users, enter a list of user IDs separated by commas (e.g. `1,5,3`).
+location_id | <strong>integer, string array</strong><br />The ID of the location to get shifts for. For multiple locations, enter a list of location IDs separated by commas.
+site_id | <strong>integer, string array</strong><br />The ID of the site to get shifts for. For multiple sites, enter a list of site IDs separated by commas.
+position_id | <strong>integer, string array</strong><br />The ID of the position to get shifts for. For multiple position, enter a list of position IDs separated by commas.
+include_allopen | <strong>boolean</strong><br />Whether to include OpenShifts in the results.
+include_onlyopen | <strong>boolean</strong><br />Whether only OpenShifts should be included in the results.
+unpublished | <strong>boolean</strong><br />Whether unpublished shifts should be included in the results.
+
+<% aside do %>
+OpenShifts will be included in the results as long as either `include_allopen` or `include_onlyopen` is `true`.
+<% end %>
 
 
 
@@ -88,6 +96,8 @@ $result = $wiw->get("shifts/1337");
 }
 <% end %>
 
+Gets the details of an existing shift.
+
 ### HTTP Request
 `GET <%=@api_prefix%>/2/shifts/{id}`
 
@@ -95,11 +105,13 @@ $result = $wiw->get("shifts/1337");
 
 Key | Description
 --- | -----------
-id | ID of the shift requested.
+id | <strong>integer</strong><br />The ID of the shift requested.
 
 
 
 ## Create/Update Shift
+
+Creates a new shift or updates an existing one.
 
 > Example Request
 
@@ -133,7 +145,7 @@ $result = $wiw->update("shifts/10000", array(...));
 
 ### Post/Put Body
 
-The `POST` and/or `PUT` body can include fields from the [Shift Object](#shifts).
+The `POST` or `PUT` body can include fields from the [Shift Object](#shifts).
 
 
 ## Acknowledge Shifts
@@ -142,13 +154,18 @@ The `POST` and/or `PUT` body can include fields from the [Shift Object](#shifts)
 
 ```shell
 curl -X POST <%=@api_prefix%>/2/shifts/acknowledge/ \
- --data '{"ids":[3543,3344]}' \
+ --data '{"ids":[34542,45434]}' \
  -H "W-Token: <%=@wiw_token%>"
 ```
 ```php
 <?php
 $wiw = new Wheniwork("<%=@wiw_token%>");
-$result = $wiw->post("shifts/acknowledge/", array("ids"=>array(34542,45434)));
+$result = $wiw->post("shifts/acknowledge/", array(
+  "ids" => array(
+    34542,
+    45434
+  )
+));
 ?>
 ```
 
@@ -170,7 +187,7 @@ This method allows you to acknowledge a group of shifts.
 
 Key | Description
 --- | -----------
-ids | Post body parameter of mulitiple shift identifiers. `[4543,23453]`
+ids | <strong>integer array</strong><br />The IDs of the shifts to acknowledge. This parameter must be in the POST body.
 
 
 ## Publish/Unpublish Shifts
@@ -185,7 +202,14 @@ curl -X POST <%=@api_prefix%>/2/shifts/publish/ \
 ```php
 <?php
 $wiw = new Wheniwork("<%=@wiw_token%>");
-$result = $wiw->post("shifts/publish/", array("ids"=>array(34542,45434)));
+$result = $wiw->post("shifts/publish/", array(
+  "ids" => array(
+    1534,
+    3543,
+    65554,
+    33444
+  )
+));
 ?>
 ```
 
@@ -210,7 +234,7 @@ These methods allow you to publish or unpublish a group of shifts.
 
 Key | Description
 --- | -----------
-ids | Post body parameter that can be used to publish multiple shifts. `[4543,23453]`
+ids | <strong>integer array</strong><br />The IDs of the shifts to publish or unpublish. This parameter must be in the POST body.
 
 
 
@@ -226,7 +250,10 @@ curl -X POST <%=@api_prefix%>/2/shifts/notify/ \
 ```php
 <?php
 $wiw = new Wheniwork("<%=@wiw_token%>");
-$result = $wiw->post("shifts/notify/", array("start"=>"2014-05-16 00:00:00", "end"=>"2014-05-19 23:59:59"));
+$result = $wiw->post("shifts/notify/", array(
+  "start" => "2014-05-16 00:00:00",
+  "end" => "2014-05-19 23:59:59"
+));
 ?>
 ```
 
@@ -240,22 +267,21 @@ $result = $wiw->post("shifts/notify/", array("start"=>"2014-05-16 00:00:00", "en
 }
 <% end %>
 
-This method allows you to notify users about new or updated shifts.
+This method allows you to notify users about new or updated shifts within a specific window.
 
 ### HTTP Request
 `POST <%=@api_prefix%>/2/shifts/notify/`
-
 
 ### Parameters
 
 Key | Description
 --- | -----------
-start | <strong>datetime</strong><br />Start time for a notify window
-end | <strong>datetime</strong><br />End time for a notify window
-user_id | <strong>integer, array</strong><br />Only notify shifts for a user, or multiple (e.g. `[1,5,3]`)
-location_id | <strong>integer, array</strong><br />Only notify shifts for a location, or multiple.
-position_id | <strong>integer, array</strong><br />Only notify shifts for a position, or multiple.
-site_id | <strong>integer, array</strong><br />Only notify shifts for a site, or multiple.
+start | <strong>datetime</strong><br />Start time for the notification window.
+end | <strong>datetime</strong><br />End time for the notification window.
+user_id | <strong>integer, integer array</strong><br />The ID of the user to notify. For multiple users, enter an array of user IDs (e.g. `[1,5,3]`).
+location_id | <strong>integer, integer array</strong><br />The ID of the location to send notifications for. For multiple locations, enter an array of location IDs.
+site_id | <strong>integer, integer array</strong><br />The ID of the site to send notifications for. For multiple sites, enter an array of site IDs.
+position_id | <strong>integer, integer array</strong><br />The ID of the position to send notifications for. For multiple position, enter an array of position IDs.
 
 > Example Request
 
@@ -289,7 +315,7 @@ You can also send a notification about just one shift using the following:
 
 Key | Description
 --- | -----------
-id | <strong>integer</strong><br />ID of the shift you want to notify.
+id | <strong>integer</strong><br />ID of the shift you want to send notifications about.
 
 
 ## Delete Shift
@@ -297,7 +323,7 @@ id | <strong>integer</strong><br />ID of the shift you want to notify.
 > Example Request
 
 ```shell
-curl -X DELETE <%=@api_prefix%>/2/shifts/1 \
+curl -X DELETE <%=@api_prefix%>/2/shifts/1337 \
  -H "W-Token: <%=@wiw_token%>"
 ```
 ```php
@@ -315,6 +341,8 @@ $result = $wiw->delete("shifts/1337");
 }
 <% end %>
 
+Deletes an existing shift.
+
 ### HTTP Request
 `DELETE <%=@api_prefix%>/2/shifts/{id}`
 
@@ -322,8 +350,12 @@ $result = $wiw->delete("shifts/1337");
 
 Key | Description
 --- | -----------
-id | ID of the shift requested.
-ids | Optional query parameter that can be used to delete multiple shifts. `?ids=5,2,34`
+id | <strong>integer</strong><br />ID of the shift to delete.
+ids | <strong>integer array</strong><br />Array of IDs of the shifts to delete.
+
+<% aside do %>
+If the `id` parameter is present, it will take precedence over `ids`.
+<% end %>
 
 
 


### PR DESCRIPTION
Documentation for shifts has been improved overall. All parameters now have a type annotation, all shell and PHP examples use the same data, and text has been clarified wherever possible.

One specific point of confusion this resolves is how the `start` and `end` parameters work on the Listing Shifts endpoint. The examples now use both date and time, instead of just date. There have been several support tickets stemming from confusion over that point.