### PR TITLE
Add common "param" method for query parameters

### DIFF
--- a/lib/common.rb
+++ b/lib/common.rb
@@ -45,6 +45,18 @@ class Common < Middleman::Extension
 
       concat output
     end
+
+    def param(name, type=nil, options={})
+      content = capture do yield end
+
+      output = "#{name} | "
+      if (type)
+        output << "<strong>#{type}</strong><br />"
+      end
+      output << content
+
+      concat output
+    end
     
   end
 end


### PR DESCRIPTION
Having a single common method for parameters in a table will let us manage the formatting of those parameters in a saner way later on. As it is, if we ever want to change how the type of a parameter is
displayed, we have to change it tediously across the entire docs.

We will have to do that once for this change but then we would never have to do that again.

## Examples

### Without Type

**Before:**
```erb
end | End time for the search window. The default is exactly three days from the start time.
```

**After:**
```erb
<% param "end" do %>End time for the search window. The default is exactly three days from the start time.<% end %>
```

### With Type

**Before:**
```erb
start | <strong>datetime</strong><br />Start time for the search window. The default is the current date and time.
```

**After:**
```erb
<% param "start", "datetime" do %>Start time for the search window. The default is the current date and time.<% end %>
```