### PR TITLE
Make print_table use param method

### DIFF
--- a/lib/api_objects.rb
+++ b/lib/api_objects.rb
@@ -22,7 +22,7 @@ class ApiObjects < Middleman::Extension
       html << "Parameter | Description\n"
       html << "--------- | -----------\n"
       object.each do |key, obj|
-        html << "#{key} | <strong>#{obj['type']}</strong><br />#{obj['description']}\n"
+        html << make_param(key, obj['description'], obj['type'], newline: true)
       end
       return html
     end

--- a/lib/common.rb
+++ b/lib/common.rb
@@ -46,16 +46,23 @@ class Common < Middleman::Extension
       concat output
     end
 
-    def param(name, type=nil, options={})
-      content = capture do yield end
-
+    def make_param(name, content, type=nil, options={})
       output = "#{name} | "
-      if (type)
+      if type
         output << "<strong>#{type}</strong><br />"
       end
       output << content
 
-      concat output
+      if options[:newline]
+        output << "\n"
+      end
+
+      return output
+    end
+
+    def param(name, type=nil, options={})
+      content = capture do yield end
+      concat make_param(name, content, type)
     end
     
   end


### PR DESCRIPTION
The parameters outputted by print_table were still outputting raw Markdown instead of being formatted using the `param` method. Now there is a `make_param` method that returns a string, and the `param` method uses this to build the parameter to output.