### PR TITLE
Switch JSON :minimal to :verbose

### DIFF
--- a/lib/api_objects.rb
+++ b/lib/api_objects.rb
@@ -8,9 +8,10 @@ class ApiObjects < Middleman::Extension
     # Add helper functions to the App scope
     app.extend ApiAppMethods
   end
-  module ApiAppMethods
 
+  module ApiAppMethods
   end
+
   helpers do
     def print_table(object, options={})
       html = ""
@@ -26,26 +27,35 @@ class ApiObjects < Middleman::Extension
       end
       return html
     end
+
     def print_json_as_php_array(object, options={})
       formatted = {}
-      inc = (options[:include]||{}).inject({}) { |h,(k,v)| h[k] = {'show' => true, 'value' => v}; h }
-      object.merge(inc).each do |key,obj|
-        if !options[:minimal] || obj['show']
-          formatted.merge!(key=>obj['value'])
+      inc = (options[:include] || {}).inject({}) do |hash, (key, value)|
+        hash[key] = {'value' => value, 'show' => true}
+        hash
+      end
+      object.merge(inc).each do |key, obj|
+        if options[:verbose] || obj['show']
+          formatted.merge!(key => obj['value'])
         end
       end
 
       json_text = JSON.generate(formatted)
       return json_text.gsub(/\{(.*)\}/, 'array(\1)').gsub(/\:/, ' => ')
     end
+
     def print_json(object, options={})
       formatted = {}
-      inc = (options[:include]||{}).inject({}) { |h,(k,v)| h[k] = {'show' => true, 'value' => v}; h }
-      object.merge(inc).each do |key,obj|
-        if !options[:minimal] || obj['show']
-          formatted.merge!(key=>obj['value'])
+      inc = (options[:include] || {}).inject({}) do |hash, (key, value)|
+        hash[key] = {'value' => value, 'show' => true}
+        hash
+      end
+      object.merge(inc).each do |key, obj|
+        if options[:verbose] || obj['show']
+          formatted.merge!(key => obj['value'])
         end
       end
+
       json = JSON.pretty_generate(formatted)
       return json
     end

--- a/source/index.md.erb
+++ b/source/index.md.erb
@@ -64,7 +64,7 @@ $result = Wheniwork::login(
 {
   "login": <%= print_json(data.objects['login']) %>,
   "users": [
-    <%= print_json(data.objects['user'],:minimal=>true) %> 
+    <%= print_json(data.objects['user']) %> 
   ]
 }
 <% end %>
@@ -110,7 +110,7 @@ $result = $wiw->post("users/autologin");
 
 <% json do %>
 {
-  "user": <%= print_json(data.objects['user'], :minimal=>true, :include=>{
+  "user": <%= print_json(data.objects['user'], :include=>{
     :token=>@wiw_token
   }) %>,
   "hash": "the_auto_login_hash"

--- a/source/methods/accounts.md.erb
+++ b/source/methods/accounts.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['account']) %>
+<%= print_json(data.objects['account'], :verbose => true) %>
 <% end %>
 
 Accounts are objects that define a business account with When I Work. Every user must be associated with an account in order to be able to access Shifts and other data.
@@ -28,14 +28,14 @@ $result = $wiw->get("account");
 
 <% json do %>
 {
-  "account": <%= print_json(data.objects['account'], :minimal => true, :include => {
+  "account": <%= print_json(data.objects['account'], :include => {
       'id' => 11,
       'master_id' => 11,
       'company' => '123 Company',
       'subdomain' => '123-company'
   }) %>,
   "accounts": [
-    <%= print_json(data.objects['account'], :minimal => true, :include => {
+    <%= print_json(data.objects['account'], :include => {
       'id' => 12,
       'master_id' => 11,
       'company' => 'ABC Company',
@@ -77,7 +77,7 @@ $result = $wiw->get("account/11");
 
 <% json do %>
 {
-  "account": <%= print_json(data.objects['account'], :minimal => true, :include => {
+  "account": <%= print_json(data.objects['account'], :include => {
     'id' => 11,
     'master_id' => 11,
     'company' => '123 Company',

--- a/source/methods/annotations.md.erb
+++ b/source/methods/annotations.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['annotation']) %>
+<%= print_json(data.objects['annotation'], :verbose => true) %>
 <% end %>
 
 Annotations convey important information to all staff for the given location(s) and date range.

--- a/source/methods/availabilities.md.erb
+++ b/source/methods/availabilities.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['availability']) %>
+<%= print_json(data.objects['availability'], :verbose => true) %>
 <% end %>
 
 Availabilities are objects that define a user's availability to be assigned shifts during a certain period of time.
@@ -17,7 +17,7 @@ specified non-default availability.
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['availabilityitem'], :minimal => true) %>
+<%= print_json(data.objects['availabilityitem']) %>
 <% end %>
 
 <%= print_table(data.objects['availabilityitem'], :header => :availability_item) %>
@@ -43,14 +43,14 @@ $result = $wiw->get("availabilities");
 <% json do %>
 {
   "availabilities": [
-    <%= print_json(data.objects['availability'], :minimal => true) %>,
-    <%= print_json(data.objects['availability'], :minimal => true, :include => {
+    <%= print_json(data.objects['availability']) %>,
+    <%= print_json(data.objects['availability'], :include => {
       'id' => 11,
       'user_id' => 453,
       'name' => "George's availability",
       'description' => "George M.'s School Year Availability"
     }) %>,
-    <%= print_json(data.objects['availability'], :minimal => true, :include => {
+    <%= print_json(data.objects['availability'], :include => {
       'id' => 12,
       'user_id' => 456,
       'name' => "Lorraine's availability",
@@ -84,24 +84,24 @@ $result = $wiw->get("availabilities/10");
 
 <% json do %>
 {
-  "availability": <%= print_json(data.objects['availability'], :minimal => true) %>,
+  "availability": <%= print_json(data.objects['availability']) %>,
   "availabilityitems": [
-    <%= print_json(data.objects['availabilityitem'], :minimal => true) %>,
-    <%= print_json(data.objects['availabilityitem'], :minimal => true, :include => {
+    <%= print_json(data.objects['availabilityitem']) %>,
+    <%= print_json(data.objects['availabilityitem'], :include => {
       'id' => 12,
       'availability_id' => 10,
       'day' => 1,
       'start_time' => '08:00:00',
       'end_time' => '18:30:00'
     }) %>,
-    <%= print_json(data.objects['availabilityitem'], :minimal => true, :include => {
+    <%= print_json(data.objects['availabilityitem'], :include => {
       'id' => 13,
       'availability_id' => 10,
       'day' => 3,
       'start_time' => '05:00:00',
       'end_time' => '14:00:00'
     }) %>,
-    <%= print_json(data.objects['availabilityitem'], :minimal => true, :include => {
+    <%= print_json(data.objects['availabilityitem'], :include => {
       'id' => 14,
       'availability_id' => 10,
       'day' => 5,
@@ -137,24 +137,24 @@ curl <%=@api_prefix%>/2/availabilities/items?user_id=371&start=2014-01-01 8:00am
 
 <% json do %>
 {
-  "availability": <%= print_json(data.objects['availability'], :minimal => true) %>,
+  "availability": <%= print_json(data.objects['availability']) %>,
   "availabilityitems": [
-    <%= print_json(data.objects['availabilityitem'], :minimal => true) %>,
-    <%= print_json(data.objects['availabilityitem'], :minimal => true, :include => {
+    <%= print_json(data.objects['availabilityitem']) %>,
+    <%= print_json(data.objects['availabilityitem'], :include => {
       'id' => 12,
       'availability_id' => 10,
       'day' => 1,
       'start_time' => '08:00:00',
       'end_time' => '18:30:00'
     }) %>,
-    <%= print_json(data.objects['availabilityitem'], :minimal => true, :include => {
+    <%= print_json(data.objects['availabilityitem'], :include => {
       'id' => 13,
       'availability_id' => 10,
       'day' => 3,
       'start_time' => '05:00:00',
       'end_time' => '14:00:00'
     }) %>,
-    <%= print_json(data.objects['availabilityitem'], :minimal => true, :include => {
+    <%= print_json(data.objects['availabilityitem'], :include => {
       'id' => 14,
       'availability_id' => 10,
       'day' => 5,

--- a/source/methods/blocks.md.erb
+++ b/source/methods/blocks.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['block']) %>
+<%= print_json(data.objects['block'], :verbose => true) %>
 <% end %>
 
 <%= print_table(data.objects['block'], :header => :block) %>
@@ -27,13 +27,13 @@ $result = $wiw->get("blocks");
 <% json do %>
 {
   "blocks": [
-    <%= print_json(data.objects['block'], :minimal => true) %>,
-    <%= print_json(data.objects['block'], :minimal => true, :include => {
+    <%= print_json(data.objects['block']) %>,
+    <%= print_json(data.objects['block'], :include => {
       'id' => 183,
       'start_time' => '06:00:00',
       'end_time' => '14:30:00'
     }) %>,
-    <%= print_json(data.objects['block'], :minimal => true, :include => {
+    <%= print_json(data.objects['block'], :include => {
       'id' => 204,
       'start_time' => '08:45:00',
       'end_time' => '16:30:00'
@@ -66,7 +66,7 @@ $result = $wiw->get("block/233");
 
 <% json do %>
 {
-  "block": <%= print_json(data.objects['block'], :minimal => true) %>
+  "block": <%= print_json(data.objects['block']) %>
 }
 <% end %>
 

--- a/source/methods/devices.md.erb
+++ b/source/methods/devices.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['device']) %>
+<%= print_json(data.objects['device'], :verbose => true) %>
 <% end %>
 
 Devices receive push notifications to communicate important information to staff.
@@ -75,7 +75,7 @@ $result = $wiw->get("devices/1739");
 > Example Response
 
 <% json do %>
-<%= print_json(data.objects['device'], :minimal=>true) %>
+<%= print_json(data.objects['device']) %>
 <% end %>
 
 ### HTTP Request

--- a/source/methods/locations.md.erb
+++ b/source/methods/locations.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['location']) %>
+<%= print_json(data.objects['location'], :verbose => true) %>
 <% end %>
 
 Locations are the main physical locations where your business operates and where employees, managers, and supervisors are assigned.
@@ -30,8 +30,8 @@ $result = $wiw->get("locations");
 <% json do %>
 {
   "locations": [
-    <%= print_json(data.objects['location'], :minimal => true) %>,
-    <%= print_json(data.objects['location'], :minimal => true, :include => {
+    <%= print_json(data.objects['location']) %>,
+    <%= print_json(data.objects['location'], :include => {
       'id' => 137,
       'name' => 'Uptown',
       'address' => '100 Courthouse Square, Hill Valley, CA 12345',
@@ -68,7 +68,7 @@ $result = $wiw->get("locations/136");
 
 <% json do %>
 {
-  "location": <%= print_json(data.objects['location'], :minimal => true) %>
+  "location": <%= print_json(data.objects['location']) %>
 }
 <% end %>
 

--- a/source/methods/messages.md.erb
+++ b/source/methods/messages.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['message']) %>
+<%= print_json(data.objects['message'], :verbose => true) %>
 <% end %>
 
 <%= print_table(data.objects['message'], :header => :message) %>
@@ -22,14 +22,14 @@ curl <%=@api_prefix%>/2/messages?request_id=123 \
 <% json do %>
 {
   "messages": [
-    <%= print_json(data.objects['message'], :minimal => true) %>,
-    <%= print_json(data.objects['message'], :minimal => true, :include => {
+    <%= print_json(data.objects['message']) %>,
+    <%= print_json(data.objects['message'], :include => {
       'id' => 456,
       'user_id' => 14,
       'title' => 'Approved',
       'content' => 'This request has been approved'
     }) %>,
-    <%= print_json(data.objects['message'], :minimal => true, :include => {
+    <%= print_json(data.objects['message'], :include => {
       'id' => 789,
       'user_id' => 14,
       'title' => 'Canceled',
@@ -66,7 +66,7 @@ curl <%=@api_prefix%>/2/messages/61 \
 
 <% json do %>
 {
-  "message": <%= print_json(data.objects['message'], :minimal => true) %>
+  "message": <%= print_json(data.objects['message']) %>
 }
 <% end %>
 

--- a/source/methods/payrolls.md.erb
+++ b/source/methods/payrolls.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['payroll']) %>
+<%= print_json(data.objects['payroll'], :verbose => true) %>
 <% end %>
 
 <%= print_table(data.objects['payroll'], :header => :user) %>
@@ -20,13 +20,13 @@ curl <%=@api_prefix%>/2/payrolls \
 <% json do %>
 {
   "payrolls": [
-    <%= print_json(data.objects['payroll'], :minimal => true) %>,
-    <%= print_json(data.objects['payroll'], :minimal => true, :include => {
+    <%= print_json(data.objects['payroll']) %>,
+    <%= print_json(data.objects['payroll'], :include => {
       'id' => 25,
       'start_date' => 'Wed, 12 Feb 2014 00:00:00 -0600',
       'end_date'  =>  'Tue, 25 Feb 2014 00:00:00 -0600'
     }) %>,
-    <%= print_json(data.objects['payroll'], :minimal => true, :include => {
+    <%= print_json(data.objects['payroll'], :include => {
       'id' => 26,
       'start_date' => 'Wed, 29 Jan 2014 00:00:00 -0600', 
       'end_date'  =>  'Tue, 11 Feb 2014 00:00:00 -0600'
@@ -63,16 +63,16 @@ curl <%=@api_prefix%>/2/payrolls/24 \
 
 <% json do %>
 {
-  "payroll": <%= print_json(data.objects['payroll'], :minimal => true) %>,
+  "payroll": <%= print_json(data.objects['payroll']) %>,
   "payrollhours": [
-    <%= print_json(data.objects['payrollhours'], :minimal => true) %>,
-    <%= print_json(data.objects['payrollhours'], :minimal => true, :include => {
+    <%= print_json(data.objects['payrollhours']) %>,
+    <%= print_json(data.objects['payrollhours'], :include => {
       'id' => 101,
       'hours' => 10,
       'rate' => 10,
       'total' => 100
     }) %>,
-    <%= print_json(data.objects['payrollhours'], :minimal => true, :include => {
+    <%= print_json(data.objects['payrollhours'], :include => {
       'id' => 102,
       'hours' => 5,
       'rate' => 11,

--- a/source/methods/plans.md.erb
+++ b/source/methods/plans.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['plan']) %>
+<%= print_json(data.objects['plan'], :verbose => true) %>
 <% end %>
 
 Get all plans.

--- a/source/methods/positions.md.erb
+++ b/source/methods/positions.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['position']) %>
+<%= print_json(data.objects['position'], :verbose => true) %>
 <% end %>
 
 Positions are the different titles that employees can be grouped into.
@@ -28,13 +28,13 @@ $result = $wiw->get("positions");
 <% json do %>
 {
   "positions": [
-    <%= print_json(data.objects['position'], :minimal => true) %>,
-    <%= print_json(data.objects['position'], :minimal => true, :include => {
+    <%= print_json(data.objects['position']) %>,
+    <%= print_json(data.objects['position'], :include => {
         'id' => 5,
         'name' => 'Bagger',
         'color' => 'FF6666'
     }) %>,
-    <%= print_json(data.objects['position'], :minimal => true, :include => {
+    <%= print_json(data.objects['position'], :include => {
         'id' => 6,
         'name' => 'Cashier',
         'color' => '0066FF'
@@ -67,7 +67,7 @@ $result = $wiw->get("positions/32");
 
 <% json do %>
 {
-  "position": <%= print_json(data.objects['position'], :minimal => true) %>
+  "position": <%= print_json(data.objects['position']) %>
 }
 <% end %>
 

--- a/source/methods/requests.md.erb
+++ b/source/methods/requests.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['request']) %>
+<%= print_json(data.objects['request'], :verbose => true) %>
 <% end %>
 
 <%= print_table(data.objects['request'], :header => :request) %>
@@ -31,24 +31,24 @@ $result = $wiw->get("requests", array(
 <% json do %>
 {
   "requests": [
-    <%= print_json(data.objects['request'], :minimal => true) %>,
-    <%= print_json(data.objects['request'], :minimal => true, :include => {
+    <%= print_json(data.objects['request']) %>,
+    <%= print_json(data.objects['request'], :include => {
       'id' => '55',
       'start_time' => 'Mon, 24 Mar 2014 08:00:00 -0600',
       'end_time' => 'Fri, 28 Mar 2014 08:00:00 -0600'
     }) %>
   ],
   "messages": [
-    <%= print_json(data.objects['message'], :minimal => true, :include => {
+    <%= print_json(data.objects['message'], :include => {
       'request_id' => '54'
     }) %>,
-    <%= print_json(data.objects['message'], :minimal => true, :include => {
+    <%= print_json(data.objects['message'], :include => {
       'id' => '66',
       'request_id' => '54',
       'title' => 'Request Approved',
       'message' => 'This Request has been approved'
     }) %>,
-    <%= print_json(data.objects['message'], :minimal => true, :include => {
+    <%= print_json(data.objects['message'], :include => {
       'id' => '68',
       'request_id' => '55',
       'title' => 'Request Approved',
@@ -56,10 +56,10 @@ $result = $wiw->get("requests", array(
     }) %>
   ],
   "users": [
-    <%= print_json(data.objects['user'], :minimal => true, :include => {
+    <%= print_json(data.objects['user'], :include => {
       'id' => 135
     }) %>,
-    <%= print_json(data.objects['user'], :minimal => true, :include => {
+    <%= print_json(data.objects['user'], :include => {
       'id' => 27384,
       'first_name' => 'Emmett',
       'last_name' => 'Brown'
@@ -100,12 +100,12 @@ $result = $wiw->get("requests/65");
 
 <% json do %>
 {
-  "request": <%= print_json(data.objects['request'], :minimal => true) %>,
+  "request": <%= print_json(data.objects['request']) %>,
   "messages": [
-    <%= print_json(data.objects['message'], :minimal => true, :include => {
+    <%= print_json(data.objects['message'], :include => {
       'request_id' => '54'
     }) %>,
-    <%= print_json(data.objects['message'], :minimal => true, :include => {
+    <%= print_json(data.objects['message'], :include => {
       'id' => '66',
       'request_id' => '54',
       'title' => 'Request Approved',
@@ -113,10 +113,10 @@ $result = $wiw->get("requests/65");
     }) %>
   ],
   "users": [
-    <%= print_json(data.objects['user'], :minimal => true, :include => {
+    <%= print_json(data.objects['user'], :include => {
       'id' => 135
     }) %>,
-    <%= print_json(data.objects['user'], :minimal => true, :include => {
+    <%= print_json(data.objects['user'], :include => {
       'id' => 27384,
       'first_name' => 'Emmett',
       'last_name' => 'Brown'

--- a/source/methods/send.md.erb
+++ b/source/methods/send.md.erb
@@ -1,7 +1,7 @@
 > Example Post Data
 
 <% json do %>
-<%= print_json(data.objects['send']) %>
+<%= print_json(data.objects['send'], :verbose => true) %>
 <% end %>
 
 Send an email to a group of users.

--- a/source/methods/shifts.md.erb
+++ b/source/methods/shifts.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['shift']) %>
+<%= print_json(data.objects['shift'], :verbose => true) %>
 <% end %>
 
 Shifts provide the basis for scheduling. Many other objects, including Locations, Positions, Sites, and Users, all link through Shifts.
@@ -35,8 +35,8 @@ $result = $wiw->get("shifts", array(
   "start": "Wed, 05 Mar 2014 00:00:00 -0600",
   "end": "Sat, 08 Mar 2014 23:59:59 -0600",
   "shifts": [
-    <%= print_json(data.objects['shift'], :minimal=>true) %>,
-    <%= print_json(data.objects['shift'], :minimal=>true, :include=>{
+    <%= print_json(data.objects['shift']) %>,
+    <%= print_json(data.objects['shift'], :include=>{
       'id' => 27384,
       'start_time' => 'Sat, 08 Mar 2014 09:00:00 -0600',
       'end_time' => 'Sat, 08 Mar 2014 17:00:00 -0600'
@@ -89,7 +89,7 @@ $result = $wiw->get("shifts/1337");
 
 <% json do %>
 {
-  "shift": <%= print_json(data.objects['shift'], :minimal => true, :include => {
+  "shift": <%= print_json(data.objects['shift'], :include => {
     :id => 1337,
     :notes => "Come in early today."
   }) %>
@@ -131,7 +131,7 @@ $result = $wiw->update("shifts/10000", array(...));
 
 <% json do %>
 {
-  "shift": <%= print_json(data.objects['shift'], :minimal => true, :include => {
+  "shift": <%= print_json(data.objects['shift'], :include => {
     :notes=>"Come in early today."
   }) %>
 }

--- a/source/methods/sites.md.erb
+++ b/source/methods/sites.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['site']) %>
+<%= print_json(data.objects['site'], :verbose => true) %>
 <% end %>
 
 Sites are off-site locations where users of a location can be assigned and scheduled.
@@ -29,8 +29,8 @@ $result = $wiw->get("sites");
 <% json do %>
 {
   "sites": [
-    <%= print_json(data.objects['site'], :minimal => true) %>,
-    <%= print_json(data.objects['site'], :minimal => true, :include => {
+    <%= print_json(data.objects['site']) %>,
+    <%= print_json(data.objects['site'], :include => {
       'id' => 4,
       'name' => 'Lone Pine'
     }) %>
@@ -62,7 +62,7 @@ $result = $wiw->get("sites/9");
 
 <% json do %>
 {
-  "site": <%= print_json(data.objects['site'], :minimal => true) %>
+  "site": <%= print_json(data.objects['site']) %>
 }
 <% end %>
 

--- a/source/methods/swaps.md.erb
+++ b/source/methods/swaps.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['swap']) %>
+<%= print_json(data.objects['swap'], :verbose => true) %>
 <% end %>
 
 <%= print_table(data.objects['swap'], :header => :swap) %>
@@ -27,19 +27,19 @@ $result = $wiw->get("swaps");
 <% json do %>
 {
   "swaps": [
-    <%= print_json(data.objects['swap'], :minimal => true) %>
+    <%= print_json(data.objects['swap']) %>
   ],
   "messages" : [
-    <%= print_json(data.objects['message'], :minimal => true, :include => {
+    <%= print_json(data.objects['message'], :include => {
       'swap_id' => '2238'
     }) %>
   ],
   "shifts" : [
-    <%= print_json(data.objects['shift'], :minimal => true) %>
+    <%= print_json(data.objects['shift']) %>
   ],
   "users" : [
-    <%= print_json(data.objects['user'], :minimal => true) %>,
-    <%= print_json(data.objects['user'], :minimal => true, :include => {
+    <%= print_json(data.objects['user']) %>,
+    <%= print_json(data.objects['user'], :include => {
       'id' => 27384,
       'first_name' => 'Emmett'
     }) %>
@@ -72,19 +72,19 @@ $result = $wiw->get("swaps/22");
 <% json do %>
 {
   "swaps": [
-    <%= print_json(data.objects['swap'], :minimal => true) %>
+    <%= print_json(data.objects['swap']) %>
   ],
   "messages" : [
-    <%= print_json(data.objects['message'], :minimal => true, :include => {
+    <%= print_json(data.objects['message'], :include => {
       'swap_id' => '2238'
     }) %>
   ],
   "shifts" : [
-    <%= print_json(data.objects['shift'], :minimal => true) %>
+    <%= print_json(data.objects['shift']) %>
   ],
   "users" : [
-    <%= print_json(data.objects['user'], :minimal => true) %>,
-    <%= print_json(data.objects['user'], :minimal => true, :include => {
+    <%= print_json(data.objects['user']) %>,
+    <%= print_json(data.objects['user'], :include => {
       'id' => 27384,
       'first_name' => 'Emmett'
     }) %>
@@ -133,33 +133,33 @@ $result = $wiw->create("swaps", array(
 <% json do %>
 {
   "swaps": [
-    <%= print_json(data.objects['swap'], :minimal => true) %>
+    <%= print_json(data.objects['swap']) %>
   ],
   "messages": [
-    <%= print_json(data.objects['message'], :minimal => true, :include => {
+    <%= print_json(data.objects['message'], :include => {
       'swap_id' => '2238'
     }) %>
   ],
   "shifts": [
-    <%= print_json(data.objects['shift'], :minimal => true, :include => {
+    <%= print_json(data.objects['shift'], :include => {
       'id' => '1047'
     }) %>,
-    <%= print_json(data.objects['shift'], :minimal => true, :include => {
+    <%= print_json(data.objects['shift'], :include => {
       'id' => '1046'
     }) %>
   ],
   "users": [
-    <%= print_json(data.objects['user'], :minimal => true, :include => {
+    <%= print_json(data.objects['user'], :include => {
       'id' => 134,
       'first_name' => 'Emmett',
       'last_name' => 'Brown'
     }) %>,
-    <%= print_json(data.objects['user'], :minimal => true, :include => {
+    <%= print_json(data.objects['user'], :include => {
       'id' => 132,
       'first_name' => 'Lorraine',
       'last_name' => 'Tannen'
     }) %>,
-    <%= print_json(data.objects['user'], :minimal => true, :include => {
+    <%= print_json(data.objects['user'], :include => {
       'id' => 110,
       'first_name' => 'Goldie',
       'last_name' => 'Wilson'

--- a/source/methods/templates.md.erb
+++ b/source/methods/templates.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['template']) %>
+<%= print_json(data.objects['template'], :verbose => true) %>
 <% end %>
 
 Templates allow you to create a group of shifts that can be used to make scheduling easier.
@@ -23,10 +23,10 @@ curl <%=@api_prefix%>/2/templates/ \
 <% json do %>
 {
   "templates": [
-    <%= print_json(data.objects['template'], :minimal => true) %>
+    <%= print_json(data.objects['template']) %>
   ],
   "templateshifts" : [
-    <%= print_json(data.objects['templateshift'], :minimal => true) %>
+    <%= print_json(data.objects['templateshift']) %>
   ]
 }
 <% end %>
@@ -50,16 +50,16 @@ curl <%=@api_prefix%>/2/templates/12 \
 <% json do %>
 {
   "templates": [
-    <%= print_json(data.objects['template'], :minimal => true) %>
+    <%= print_json(data.objects['template']) %>
   ],
   "templateshifts" : [
-    <%= print_json(data.objects['templateshift'], :minimal => true) %>,
-    <%= print_json(data.objects['templateshift'], :minimal => true, :include => {
+    <%= print_json(data.objects['templateshift']) %>,
+    <%= print_json(data.objects['templateshift'], :include => {
       'id' => '144',
       'start_time' => 'Tue, 18 Feb 2014 08:00:00 -0600',
       'end_time' => 'Tue, 18 Feb 2014 17:00:00 -0600'
     }) %>,
-    <%= print_json(data.objects['templateshift'], :minimal => true, :include => {
+    <%= print_json(data.objects['templateshift'], :include => {
       'id' => '148',
       'start_time' => 'Wed, 19 Feb 2014 08:30:00 -0600',
       'end_time' => 'Wed, 19 Feb 2014 16:00:00 -0600'
@@ -103,7 +103,7 @@ Key | Description
 <% json do %>
 {
   "templates": [
-    <%= print_json(data.objects['template'], :minimal => true, :include => {
+    <%= print_json(data.objects['template'], :include => {
       'name' => 'Cafe 80\'s February Shift Template',
       'start' => '2014-02-01',
       'end' => '2014-02-28',
@@ -113,7 +113,7 @@ Key | Description
     }) %>
   ],
   "templateshifts" : [
-    <%= print_json(data.objects['templateshift'], :minimal => true, :include => {
+    <%= print_json(data.objects['templateshift'], :include => {
       'position_id' => '172',
       'user_id' => '135',
       'location_id' => 137

--- a/source/methods/times.md.erb
+++ b/source/methods/times.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['times']) %>
+<%= print_json(data.objects['times'], :verbose => true) %>
 <% end %>
 
 <%= print_table(data.objects['times'], :header => :user) %>
@@ -20,20 +20,20 @@ curl <%=@api_prefix%>/2/times \
 <% json do %>
 {
   "times": [
-    <%= print_json(data.objects['times'], :minimal => true) %>
+    <%= print_json(data.objects['times']) %>
   ],
   "punches": [
-    <%= print_json(data.objects['punch'], :minimal => true) %>,
-    <%= print_json(data.objects['punch'], :minimal => true, :include => {
+    <%= print_json(data.objects['punch']) %>,
+    <%= print_json(data.objects['punch'], :include => {
       'id' => 150135,
       'type' => 2
     }) %>
   ],
   "shifts": [
-    <%= print_json(data.objects['shift'], :minimal => true) %>
+    <%= print_json(data.objects['shift']) %>
   ],
   "users": [
-    <%= print_json(data.objects['user'], :minimal => true) %>
+    <%= print_json(data.objects['user']) %>
   ]
 }
 <% end %>
@@ -68,7 +68,7 @@ curl <%=@api_prefix%>/2/times/11 \
 <% json do %>
 {
   "times": [
-    <%= print_json(data.objects['times'], :minimal => true) %>
+    <%= print_json(data.objects['times']) %>
   ]
 }
 <% end %>
@@ -119,16 +119,16 @@ curl <%=@api_prefix%>/2/times/user/4634 \
     }
   },
   "times": [
-    <%= print_json(data.objects['times'], :minimal => true) %>
+    <%= print_json(data.objects['times']) %>
   ],
   "shifts": [
-    <%= print_json(data.objects['shift'], :minimal => true) %>
+    <%= print_json(data.objects['shift']) %>
   ],
   "locations": [
-    <%= print_json(data.objects['location'], :minimal => true) %>
+    <%= print_json(data.objects['location']) %>
   ],
   "positions": [
-    <%= print_json(data.objects['position'], :minimal => true) %>
+    <%= print_json(data.objects['position']) %>
   ]
 }
 <% end %>
@@ -210,10 +210,10 @@ $result = $wiw->post("times/clockin/", array("id":"14","position_id":"102","coor
     }
   },
   "times": [
-    <%= print_json(data.objects['times'], :minimal => true) %>
+    <%= print_json(data.objects['times']) %>
   ],
   "locations": [
-    <%= print_json(data.objects['location'], :minimal => true) %>
+    <%= print_json(data.objects['location']) %>
   ]
 }
 <% end %>
@@ -280,10 +280,10 @@ $result = $wiw->post("times/clockout/", array("id":"14","position_id":"102","coo
     }
   },
   "times": [
-    <%= print_json(data.objects['times'], :minimal => true) %>
+    <%= print_json(data.objects['times']) %>
   ],
   "locations": [
-    <%= print_json(data.objects['location'], :minimal => true) %>
+    <%= print_json(data.objects['location']) %>
   ]
 }
 <% end %>

--- a/source/methods/users.md.erb
+++ b/source/methods/users.md.erb
@@ -1,7 +1,7 @@
 > Example Object
 
 <% json do %>
-<%= print_json(data.objects['user']) %>
+<%= print_json(data.objects['user'], :verbose => true) %>
 <% end %>
 
 Users are the employees, supervisors, and managers that have access to your business on When I Work.
@@ -28,8 +28,8 @@ $result = $wiw->get("users");
 <% json do %>
 {
   "users": [
-    <%= print_json(data.objects['user'], :minimal => true) %>,
-    <%= print_json(data.objects['user'], :minimal => true, :include => {
+    <%= print_json(data.objects['user']) %>,
+    <%= print_json(data.objects['user'], :include => {
       'id' => 27384,
       'first_name' => 'Jennifer',
       'last_name' => 'Parker',
@@ -71,7 +71,7 @@ $result = $wiw->get("users/1");
 
 <% json do %>
 {
-  "user": <%= print_json(data.objects['user'], :minimal => true, :include => {
+  "user": <%= print_json(data.objects['user'], :include => {
     :notes => "This user excels at awesome."
   }) %>
 }
@@ -109,7 +109,7 @@ $result = $wiw->post("users/", array(
 
 <% json do %>
 {
-  "user": <%= print_json(data.objects['user'], :minimal => true) %>
+  "user": <%= print_json(data.objects['user']) %>
 }
 <% end %>
 


### PR DESCRIPTION
When using the `print_json` method, we almost never wanted to actually print out *all* the fields of an object, so we were using the `:minimal` option almost every time. Now `:minimal` has been replaced with `:verbose`, its opposite. That way we have a sensible default, and we can only show all fields when we really want to. 

In the near future this may be expanded or revised to allow for those extra fields to be displayed, but collapsed by default.

Also tidies up `api_objects.rb`.