### PR TITLE
Fix incomplete documentation for open shift inclusion

### DIFF
--- a/source/methods/shifts.md.erb
+++ b/source/methods/shifts.md.erb
@@ -60,7 +60,8 @@ Key | Description
 <% param "location_id", "integer, string array" do %>The ID of the location to get shifts for. For multiple locations, enter a list of location IDs separated by commas.<% end %>
 <% param "site_id", "integer, string array" do %>The ID of the site to get shifts for. For multiple sites, enter a list of site IDs separated by commas.<% end %>
 <% param "position_id", "integer, string array" do %>The ID of the position to get shifts for. For multiple position, enter a list of position IDs separated by commas.<% end %>
-<% param "include_allopen", "boolean" do %>Whether to include OpenShifts in the results.<% end %>
+<% param "include_open", "boolean" do %>Whether to include OpenShifts the results.<% end %>
+<% param "include_allopen", "boolean" do %>Whether to include OpenShifts in the results, including shifts that might be conflicts.<% end %>
 <% param "include_onlyopen", "boolean" do %>Whether only OpenShifts should be included in the results.<% end %>
 <% param "unpublished", "boolean" do %>Whether unpublished shifts should be included in the results.<% end %>
 


### PR DESCRIPTION
The `include_open` and `include_allopen` parameters are slightly different.

cc @CherryPepsi 