### PR TITLE
Clarify Account Listing WEB-3054

### DIFF
--- a/source/methods/accounts.md.erb
+++ b/source/methods/accounts.md.erb
@@ -10,55 +10,7 @@ Accounts are objects that define a business account with When I Work. Every user
 
 <%= print_table(data.objects['place'], :header => :place) %>
 
-## Listing Accounts
-
-> Example Request
-
-```shell
-curl <%=@api_prefix%>/2/account \
- -H "W-Token: <%=@wiw_token%>"
-```
-```php
-<?php
-$wiw = new Wheniwork("<%=@wiw_token%>");
-$result = $wiw->get("account");
-?>
-```
-
-> Example Response
-
-<% json do %>
-{
-  "account": <%= print_json(data.objects['account'], :include => {
-      'id' => 11,
-      'master_id' => 11,
-      'company' => '123 Company',
-      'subdomain' => '123-company'
-  }) %>,
-  "accounts": [
-    <%= print_json(data.objects['account'], :include => {
-      'id' => 12,
-      'master_id' => 11,
-      'company' => 'ABC Company',
-      'subdomain' => 'ABC Company',
-      'logo' => 'https://s3.amazonaws.com/files.wheniwork.com/logos/19282.gif'
-    }) %>
-  ]
-}
-<% end %>
-
-### HTTP Request
-Listing accounts gives an object with two members: an `account` object, which specifies the primary account for a given user, and an array, `accounts`, containing all subaccounts of the primary account.
-
-`GET <%=@api_prefix%>/2/account?account_id=11,12`
-
-### Parameters
-
-Key | Description
---- | -----------
-<% param "account_id" do %>A list of account ids to retrieve (Optional; if not specified, will default to returning all accounts for a given user token)<% end %>
-
-### Features
+## Features
 
 The features that are enabled on accounts will vary. The following features are considered defaults and should be considered enabled when `all` is present:
 
@@ -106,6 +58,8 @@ $result = $wiw->get("account/11");
 Key | Description
 --- | -----------
 <% param "account_id" do %>ID of the account object to be retrieved.<% end %>
+
+If the account being queried for is a primary account, the response provides an object with two members: an `account` object, which specifies the primary account for a given user, and an array, `accounts`, containing all subaccounts of the primary account.
 
 ## Create/Update Account
 


### PR DESCRIPTION
This change came from conversation on this issue:

[WEB-3054](https://wheniwork.atlassian.net/browse/WEB-3054)

- Removing the Account Listing section
- Describing the case in which an account listing is included in the GET Account section