### PR TITLE
Add deprecation notice for batch method

### DIFF
--- a/source/methods/batch.md.erb
+++ b/source/methods/batch.md.erb
@@ -40,9 +40,13 @@ curl <%=@api_prefix%>/2/batch \
  -H "W-Token: <%=@wiw_token%>"
 ```
 
+_**This method is deprecated and will be removed in the future.** Update your code
+to make separate requests as soon as possible._
+
 Batch allows you to execute multiple requests at the same time.
 
 ### HTTP Request
+
 `POST <%=@api_prefix%>/2/batch`
 
 ### Parameters


### PR DESCRIPTION
Batching is terrible for performance and regularly causes server
timeouts due to large transfer sizes.