### PR TITLE
Recursively handle hash values in JSON

### DIFF
--- a/lib/api_objects.rb
+++ b/lib/api_objects.rb
@@ -82,7 +82,15 @@ class ApiObjects < Middleman::Extension
         end
 
         if options[:verbose] || options[:collapse] || !should_hide_field
-          formatted.merge!(key => field['value'])
+          if field['value'].is_a? Hash
+            field_json = print_json(field['value'], {
+              :collapse => options[:collapse],
+              :verbose => options[:verbose],
+            })
+            formatted.merge!(key => JSON.parse(field_json))
+          else
+            formatted.merge!(key => field['value'])
+          end
         end
       end
 


### PR DESCRIPTION
Using objects as field values with print_json resulted in unparsed output from objects.json:

```json
"place": {
  "business_name": {
    "show": true,
    "type": "string",
    "description": "(Optional) Business Name",
    "value": "When I Work"
  },
  "address": {
    "show": true,
    "type": "string",
    "description": "Place Address",
    "value": "60 Plato Blvd, St Paul, MN 55107, United States"
  }
}
```

With this update, these objects are recursively handled:

```json
"place": {
  "business_name": "When I Work",
  "address": "60 Plato Blvd, St Paul, MN 55107, United States"
}
```
