### PR TITLE
Add missing documentation for requests/swaps

### DIFF
--- a/source/methods/requests.md.erb
+++ b/source/methods/requests.md.erb
@@ -43,6 +43,9 @@ $result = $wiw->get("requests", array(
       'end_time' => 'Fri, 28 Mar 2014 08:00:00 -0600'
     }) %>
   ],
+  "more": false,
+  "page": 1,
+  "total": 2,
   "messages": [
     <%= print_json(data.objects['message'], :include => {
       'id' => 66,
@@ -85,8 +88,9 @@ Key | Description
 <% param "max_id" do %>Return all requests created before the request with the given ID.<% end %>
 <% param "user_id", "integer" do %>Optional. If present, will only return requests for the user with the given id.<% end %>
 <% param "status", "integer" do %>Optional. If present, will only return requests with the given status.<% end %>
+<% param "limit", "integer" do %>Optional. Number of requests to load per page, default is `5`.<% end %>
+<% param "page", "integer" do %>Optional. Page of results to load, default `1`.<% end %>
 <% param "include_deleted_users", "boolean" do %>Return all requests including those made by deleted users. Optional, defaults to false.<% end %>
-
 
 
 ## Get Existing Request

--- a/source/methods/swaps.md.erb
+++ b/source/methods/swaps.md.erb
@@ -34,6 +34,9 @@ $result = $wiw->get("swaps");
   "swaps": [
     <%= print_json(data.objects['swap']) %>
   ],
+  "more": false,
+  "page": 1,
+  "total": 1,
   "messages" : [
     <%= print_json(data.objects['message'], :include => {
       'swap_id' => '2238'
@@ -69,7 +72,7 @@ Key | Description
 <% param "start", "datetime" do %>Start time for the shift search window. Must be included if `end` is defined.<% end %>
 <% param "end", "datetime" do %>End time for the shift search window. Must be included if `start` is defined.<% end %>
 <% param "limit", "integer" do %>The number of swaps to include per page. Default is `10`.<% end %>
-<% param "page", "integer" do %>The page of results to fetch. Default is `0`.<% end %>
+<% param "page", "integer" do %>The page of results to fetch. Default is `1`.<% end %>
 
 
 


### PR DESCRIPTION
Listing requests and swaps includes output that includes the total
number of results, the current page, and if more pages are available.

Refs WEB-3306
Refs wheniwork/wheniwork-app#3864