### PR TITLE
Documents the shift history endpoint

### DIFF
--- a/data/objects.json
+++ b/data/objects.json
@@ -242,6 +242,42 @@
       "description": "Whether the shift is an OpenShift."
     }
   },
+  "shifthistory": {
+    "type": {
+      "type": "enum",
+      "description": "Type of event. One of: `created`, `published`, `time_changed`, `break_changed`, `position_changed`, `unpublished`, `position_removed`, `site_changed`, `reassigned`, or `current`"
+    },
+    "attributes": {
+      "type": "object",
+      "show": false
+    }
+  },
+  "shifthistoryattributes": {
+    "actor": {
+        "type": "string",
+        "description": "Name of the user that initiated the change, or the assigned employee if the event is `current`"
+    },
+    "at": {
+        "type": "datetime",
+        "description": "Time of the change"
+    },
+    "start": {
+        "type": "datetime",
+        "description": "New or current shift start time, if applicable"
+    },
+    "end": {
+        "type": "datetime",
+        "description": "New or current shift end time, if applicable"
+    },
+    "break": {
+        "type": "float",
+        "description": "Length of unpaid break, in hours"
+    },
+    "user": {
+        "type": "string",
+        "description": "Name of scheduled employee, if applicable"
+    }
+  },
   "user": {
     "id": {
       "type": "integer",

--- a/source/methods/shifts.md.erb
+++ b/source/methods/shifts.md.erb
@@ -205,6 +205,77 @@ Key | Description
 <% param "ids", "integer array" do %>The IDs of the shifts to acknowledge. This parameter must be in the POST body.<% end %>
 <% param "before", "string" do %>The timestamp that represents when the shift data was last fetched from the server. This is optional, and is useful to protect against inadvertently acknowledging shifts that were updated since data was fetched.<% end %>
 
+## Get Shift History
+
+> Example Request
+
+```shell
+curl <%=@api_prefix%>/2/shifts/1337/history \
+ -H "W-Token: <%=@wiw_token%>"
+```
+```php
+<?php
+$wiw = new Wheniwork("<%=@wiw_token%>");
+$result = $wiw->get("shifts/1337/history");
+?>
+```
+
+> Example Response
+
+<% json do %>
+{
+  "shift": <%= print_json(data.objects['shift'], :include => {
+    :id => 1337,
+    :notes => "Come in early today."
+  }) %>,
+  "history": [
+    <%= print_json(data.objects['shifthistory'], :include=>{
+      'type' => 'created',
+    }) %>,
+    <%= print_json(data.objects['shifthistory'], :include=>{
+      'type' => 'time_changed',
+    }) %>,
+    <%= print_json(data.objects['shifthistory'], :include=>{
+      'type' => 'time_changed',
+    }) %>
+  ]
+}
+<% end %>
+
+Gets the history of an existing shift. Shift history events are created when one
+or more of the following elements are changed:
+
+* start_time
+* end_time
+* user_id
+* position_id
+* location_id
+* site_id
+* published
+* break_time
+* acknowledged_at
+
+History events contain `actor` and `at` fields, and can also contain one or more
+of the following optional fields depending on event type:
+
+* start
+* end
+* user
+* break
+
+There is one special event called "current" that includes the current state of
+the shift.
+
+### HTTP Request
+`GET <%=@api_prefix%>/2/shifts/{id}/history`
+
+### Parameters
+
+Key | Description
+--- | -----------
+<% param "id", "integer" do %>The ID of the shift for which to fetch history.<% end %>
+
+
 ## Publish/Unpublish Shifts
 
 > Example Request


### PR DESCRIPTION
Refs https://github.com/wheniwork/wheniwork-api/issues/98

I know we aren't actually using the shift history attributes object but the documentation is at least there now.