### PR TITLE
Add documentation for projected sales endpoint

### DIFF
--- a/data/objects.json
+++ b/data/objects.json
@@ -1987,5 +1987,37 @@
           "value": "https://s3.amazonaws.com/uploads.wheniwork.com/s/32/2014-04-06/t/5757277e91b7e.png",
           "show": true
       }
+  },
+  "projectedsales": {
+    "id": {
+      "type": "integer",
+      "description": "The ID of the projected sales object.",
+      "value": 1234,
+      "show": true
+    },
+    "account_id": {
+      "type": "integer",
+      "description": "The ID of the account to which the projected sales object belongs.",
+      "value": 10000,
+      "show": true
+    },
+    "day": {
+      "type": "string",
+      "description": "The day to which the projected sale belongs. Formatted as an [RFC 2822](http://php.net/manual/en/class.datetime.php#datetime.constants.rfc2822) date string, without the time component.",
+      "value": "Thu, 7 Oct 2016",
+      "show": true
+    },
+    "estimate": {
+      "type": "number",
+      "description": "The projected amount of money.",
+      "value": 5000,
+      "show": true
+    },
+    "location_id": {
+      "type": "integer",
+      "description": "The ID of the location to which the projected sales object belongs.",
+      "value": 136,
+      "show": true
+    }
   }
 }

--- a/source/index.md.erb
+++ b/source/index.md.erb
@@ -399,6 +399,10 @@ Including related objects is controlled by the `include_objects` parameter, whic
 
 <%= partial "methods/industries" %>
 
+# Forecasting
+
+<%= partial "methods/forecasting" %>
+
 # Timezones
 
 <%= partial "methods/timezones" %>

--- a/source/methods/forecasting.md.erb
+++ b/source/methods/forecasting.md.erb
@@ -1,0 +1,41 @@
+## Get Projected Sales
+
+> Example Request
+
+```shell
+curl <%=@api_prefix%>/2/forecasting/projected \
+ -H "W-Token: <%=@wiw_token%>"
+```
+```php
+<?php
+$wiw = new Wheniwork("<%=@wiw_token%>");
+$result = $wiw->get("forecasting/projected");
+?>
+```
+
+> Example Response
+
+<% json do %>
+{
+    "projectedsales": [
+        <%= print_json(data.objects['projectedsales']) %>,
+        <%= print_json(data.objects['projectedsales'], :include => {
+            'id' => 1235,
+            'day' => 'Thu, 8 Oct 2016',
+            'estimate' => 4500
+        }) %>
+    ]
+}
+<% end %>
+
+### HTTP Request
+
+`GET <%=@api_prefix%>/2/forecasting/projected`
+
+### Parameters
+
+Key | Description
+--- | -----------
+<% param "start", "datetime" do %>(Optional) The start of the time interval to get projected sales for.<% end %>
+<% param "end", "datetime" do %>(Optional) The end of the time interval to get projected sales for.<% end %>
+<% param "location_id", "integer" do %>(Optional) The ID of the location to get projected sales for.<% end %>


### PR DESCRIPTION
Main question: Is this a thing we want in the docs? I see no reason not to include it.
