### PR TITLE
Fix error in schedule endpoint for querying multiple positions

### DIFF
--- a/source/methods/schedule.md.erb
+++ b/source/methods/schedule.md.erb
@@ -71,7 +71,7 @@ Key | Description
 <% param "end", "datetime" do %>End time for the search window. The default is exactly three days from the start time.<% end %>
 <% param "offset", "integer" do %>Paging offset for searching users. The default is zero.<% end %>
 <% param "location_id", "integer, string array" do %>The ID of the location to get shifts for. For multiple locations, enter a list of location IDs separated by commas.<% end %>
-<% param "position_id", "integer, string array" do %>The ID of the position to get shifts for. For multiple positions, enter a list of location IDs separated by commas.<% end %>
+<% param "position_id", "integer, string array" do %>The ID of the position to get shifts for. For multiple positions, enter a list of position IDs separated by commas.<% end %>
 <% param "show_inactive", "boolean" do %>Include inactive users in the results.<% end %>
 
 <% aside do %>


### PR DESCRIPTION
👋 Hi there! First time caller. Thank you so much for providing your documentation in an open source repository so that fixes like this can occur 🙏.

This pull request resolves an error in the documentation for the `position_id` argument of the ["Fetching Schedules"](http://dev.wheniwork.com/#fetching-schedule) endpoint when multiple _position_ IDs are passed as an argument.