### PR TITLE
Add position_id as option to shifts endpoint

### DIFF
--- a/source/methods/shifts.md.erb
+++ b/source/methods/shifts.md.erb
@@ -63,6 +63,7 @@ Key | Description
 <% param "end", "datetime" do %>End time for the search window. The default is exactly three days from the start time.<% end %>
 <% param "user_id", "integer, string array" do %>The ID of the user to get shifts for. For multiple users, enter a list of user IDs separated by commas (e.g. `1,5,3`).<% end %>
 <% param "location_id", "integer, string array" do %>The ID of the location to get shifts for. For multiple locations, enter a list of location IDs separated by commas.<% end %>
+<% param "position_id", "integer, string array" do %>The ID of the position to get shifts for. For multiple positions, enter a list of position IDs separated by commas.<% end %>
 <% param "include_open", "boolean" do %>Whether to include OpenShifts in the results.<% end %>
 <% param "include_allopen", "boolean" do %>Whether to include OpenShifts in the results, including shifts that might be conflicts.<% end %>
 <% param "include_onlyopen", "boolean" do %>Whether only OpenShifts should be included in the results.<% end %>


### PR DESCRIPTION
This pull request updates the documentation of the [Listing Shifts endpoint](http://dev.wheniwork.com/#listing-shifts) to include the optional `position_id` parameter to filter shifts by a given position.

Passing this undocumented parameter seems to function as expected, but this could probably use an 👁  from the folks at @wheniwork to ensure it wasn't intentionally omitted from the documentation.